### PR TITLE
ci: Use Fedora 41, drop Fedora 39

### DIFF
--- a/.github/workflows/tft.yml
+++ b/.github/workflows/tft.yml
@@ -98,9 +98,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - platform: Fedora-39
-            ansible_version: 2.17
           - platform: Fedora-40
+            ansible_version: 2.17
+          - platform: Fedora-41
             ansible_version: 2.17
           - platform: CentOS-7-latest
             ansible_version: 2.9

--- a/contributing.md
+++ b/contributing.md
@@ -1,4 +1,4 @@
-# Contributing to the Aide Linux System Role
+# Contributing to the aide Linux System Role
 
 ## Where to start
 

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -37,6 +37,5 @@ __aide_rh_distros_fedora: "{{ __aide_rh_distros + ['Fedora'] }}"
 __aide_is_rh_distro: "{{ ansible_distribution in __aide_rh_distros }}"
 
 # Use this in conditionals to check if distro is Red Hat or clone, or Fedora
-__aide_is_rh_distro_fedora: \
-  "{{ ansible_distribution in __aide_rh_distros_fedora }}"
+__aide_is_rh_distro_fedora: "{{ ansible_distribution in __aide_rh_distros_fedora }}"
 # END - DO NOT EDIT THIS BLOCK - rh distros variables


### PR DESCRIPTION
Fedora 41 is released, and Fedora 39 will soon be unsupported

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
