### PR TITLE
test: add cleanup for cron test; fix formatting

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -71,8 +71,8 @@
   block:
     - name: Copy AIDE reference database
       ansible.builtin.copy:
-        src: "{{ aide_db_fetch_dir }}/{{ inventory_hostname }}\
-        {{ __aide_db_new_name }}"
+        src: >-
+          {{ aide_db_fetch_dir }}/{{ inventory_hostname }}{{ __aide_db_new_name }}
         dest: "{{ __aide_db_name }}"
         owner: root
         group: root
@@ -91,9 +91,11 @@
       ansible.builtin.command:
         cmd: aide --update
       register: __aide_update_result
-      failed_when: "'AIDE found NO differences between database and filesystem. Looks okay!!'\
-      not in __aide_update_result.stdout"
+      failed_when: __msg not in __aide_update_result.stdout
       changed_when: true
+      vars:
+        __msg: >-
+          AIDE found NO differences between database and filesystem. Looks okay!!
 
     - name: Fetch AIDE database
       ansible.builtin.fetch:

--- a/tests/tests_check_cron.yml
+++ b/tests/tests_check_cron.yml
@@ -2,46 +2,82 @@
 ---
 - name: Ensure that the cron is set up
   hosts: all
-  gather_facts: false
-  roles:
-    - role: linux-system-roles.aide
-      vars:
-        aide_init: true
-        aide_cron_check: true
-        aide_cron_interval: "0 12 * * *"
   tasks:
- #   - name: Print crontab 1
- #     ansible.builtin.command: cat /etc/crontab
+    - name: Install crontabs
+      package:
+        name: crontabs
 
-    - name: Check file content
-      ansible.builtin.lineinfile:
-        path: /etc/crontab
-        regexp: "^.* root /usr/sbin/aide --check"
-        line: "0 12 * * * root /usr/sbin/aide --check"
-        state: present
-      register: result
-      failed_when: result.changed
-      vars:
-        __fingerprint: system_role:aide
+    - name: Create tempfile for crontab backup
+      tempfile:
+        prefix: aide_
+        suffix: _crontab
+      register: __aide_crontab_backup
 
-- name: Ensure that the cron is not set up
-  hosts: all
-  gather_facts: false
-  roles:
-    - role: linux-system-roles.aide
-      vars:
-        aide_cron_check: false
-  tasks:
-#    - name: Print crontab 2
-#      ansible.builtin.command: cat /etc/crontab
+    - name: Backup crontab
+      copy:
+        src: /etc/crontab
+        dest: "{{ __aide_crontab_backup.path }}"
+        remote_src: true
+        mode: preserve
 
-    - name: Check file content
-      ansible.builtin.lineinfile:
-        path: /etc/crontab
-        regexp: "^.* root /usr/sbin/aide --check"
-        line: "0 12 * * * root /usr/sbin/aide --check"
-        state: present
-      register: result
-      failed_when: not result.changed
-      vars:
-        __fingerprint: system_role:aide
+    - name: Run tests
+      block:
+        - name: Run the role and set up cron
+          ansible.builtin.include_role:
+            name: linux-system-roles.aide
+          vars:
+            aide_init: true
+            aide_cron_check: true
+            aide_cron_interval: "0 12 * * *"
+
+        - name: Check file content
+          ansible.builtin.lineinfile:
+            path: /etc/crontab
+            regexp: "^.* root /usr/sbin/aide --check"
+            line: "0 12 * * * root /usr/sbin/aide --check"
+            state: present
+          register: result
+          failed_when: result is changed
+
+        - name: Run the role and and do not touch cron
+          ansible.builtin.include_role:
+            name: linux-system-roles.aide
+          vars:
+            aide_cron_interval: "0 1 * * *"
+
+        - name: Ensure file is not changed
+          ansible.builtin.lineinfile:
+            path: /etc/crontab
+            regexp: "^.* root /usr/sbin/aide --check"
+            line: "0 12 * * * root /usr/sbin/aide --check"
+            state: present
+          register: result
+          failed_when: result is changed
+
+        - name: Run the role and disable cron
+          ansible.builtin.include_role:
+            name: linux-system-roles.aide
+          vars:
+            aide_cron_check: false
+
+        - name: Ensure aide cron is removed
+          ansible.builtin.lineinfile:
+            path: /etc/crontab
+            regexp: "^.* root /usr/sbin/aide --check"
+            line: "0 12 * * * root /usr/sbin/aide --check"
+            state: present
+          register: result
+          failed_when: not result is changed
+
+      always:
+        - name: Restore crontab
+          copy:
+            src: "{{ __aide_crontab_backup.path }}"
+            dest: /etc/crontab
+            remote_src: true
+            mode: preserve
+
+        - name: Delete tempfile
+          file:
+            path: "{{ __aide_crontab_backup.path }}"
+            state: absent

--- a/tests/tests_custom_template.yml
+++ b/tests/tests_custom_template.yml
@@ -2,7 +2,6 @@
 ---
 - name: Ensure that the role runs with default parameters
   hosts: all
-  gather_facts: false  # test that role works in this case
   roles:
     - role: linux-system-roles.aide
       vars:

--- a/tests/tests_default.yml
+++ b/tests/tests_default.yml
@@ -6,21 +6,12 @@
   roles:
     - linux-system-roles.aide
   tasks:
-    - name: Check if file exists
-      block:
-        - name: Check if the file exists
-          ansible.builtin.stat:
-            path: "/etc/aide.conf"
-          register: file_check
+    - name: Check if the file exists
+      ansible.builtin.stat:
+        path: /etc/aide.conf
+      register: file_check
 
-        - name: Assert that the file exists
-          ansible.builtin.assert:
-            that:
-              - file_check.stat.exists
-            fail_msg: "The file does not exist."
-
-        - name: Check header for not present ansible_managed, fingerprint
-          include_tasks: tasks/check_not_present_header.yml
-          vars:
-            __file: /etc/aide.conf
-            __fingerprint: system_role:aide
+    - name: Assert that the file exists
+      ansible.builtin.assert:
+        that: file_check.stat.exists
+        fail_msg: The file does not exist.

--- a/tests/tests_deploy.yml
+++ b/tests/tests_deploy.yml
@@ -2,14 +2,17 @@
 ---
 - name: Ensure that the role runs with default parameters
   hosts: all
-  gather_facts: false  # test that role works in this case
   roles:
     - role: linux-system-roles.aide
       vars:
         aide_init: true
   tasks:
-    - name: Check header for ansible_managed, fingerprint
-      include_tasks: tasks/check_not_present_header.yml
-      vars:
-        __file: /etc/aide.conf
-        __fingerprint: system_role:aide
+    - name: Check if the file exists
+      ansible.builtin.stat:
+        path: /etc/aide.conf
+      register: file_check
+
+    - name: Assert that the file exists
+      ansible.builtin.assert:
+        that: file_check.stat.exists
+        fail_msg: The file does not exist.


### PR DESCRIPTION
Ensure cron test restores state of crontab after test.
Fix formatting in a few places.
Do not check ansible managed header and fingerprint unless the test
uses a custom template with header and fingerprint.
Use default for gather_facts unless otherwise needed.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
