### PR TITLE
refactor: Changed ansible_db_template to ansible_config_template

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ only.
 
 ## Role Variables
 
-### aide_db_template
+### aide_config_template
 
 This variable takes a string to specify a path where the custom template for aide.conf is located.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,7 @@
 # This file also serves as a documentation for such a variables.
 
 # Path to template file
-aide_db_template: null
+aide_config_template: null
 
 # Examples of role input variables:
 aide_db_fetch_dir: files

--- a/examples/custom-template.yml
+++ b/examples/custom-template.yml
@@ -5,7 +5,7 @@
   tasks:
     - name: Include role aide
       vars:
-        aide_db_template: /tmp/aide-custom.conf.j2
+        aide_config_template: /tmp/aide-custom.conf.j2
         aide_db_fetch_dir: files
         aide_init: true
         aide_fetch_db: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,10 +20,10 @@
 
 - name: Generate "/etc/{{ __aide_config }}"
   ansible.builtin.template:
-    src: "{{ aide_db_template }}"
+    src: "{{ aide_config_template }}"
     dest: "/etc/{{ __aide_config }}"
     mode: "0400"
-  when: aide_db_template is not none
+  when: aide_config_template is not none
 
 # - name: Print Header
 #   ansible.builtin.command: head /etc/aide.conf || true

--- a/tests/tests_custom_template.yml
+++ b/tests/tests_custom_template.yml
@@ -5,7 +5,7 @@
   roles:
     - role: linux-system-roles.aide
       vars:
-        aide_db_template: files/aide-custom.conf.j2
+        aide_config_template: files/aide-custom.conf.j2
         aide_install: true
         aide_init: true
   tasks:


### PR DESCRIPTION
Enhancement: Changed variable name `ansible_db_template` to `ansible_config_template`

Reason: As the template is for the aide.conf(5) file I found that the variable name `ansible_config_template` is a better fit than `ansible_db_template`.

Result: From the variable name you can know that it is for the `aide` configuration file and not the database.

Issue Tracker Tickets (Jira or BZ if any): Related to [RHELBU-2778](https://issues.redhat.com/browse/RHELBU-2778)
