### PR TITLE
fix: aide --check should not report changed

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -82,7 +82,7 @@
     - name: Check against AIDE reference database
       ansible.builtin.command:
         cmd: aide --check
-      changed_when: true
+      changed_when: false
 
 - name: Update AIDE database and fetch it
   when: aide_update | bool


### PR DESCRIPTION
The task "Check against AIDE reference database" should not report
changed since it does not change anything.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
