### PR TITLE
ci: Pass in __bootc_validation as boolean, not string

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -27,12 +27,12 @@ jobs:
           sudo apt install -y git
 
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.11.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.11.1"
 
       - name: Convert role to collection format
         id: collection

--- a/.github/workflows/ansible-managed-var-comment.yml
+++ b/.github/workflows/ansible-managed-var-comment.yml
@@ -25,12 +25,12 @@ jobs:
           sudo apt install -y git
 
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.11.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.11.1"
 
       - name: Run ansible-plugin-scan
         run: |

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -28,12 +28,12 @@ jobs:
           sudo apt install -y git
 
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.11.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.11.1"
 
       - name: Convert role to collection format
         run: |

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -25,7 +25,7 @@ jobs:
           sudo apt install -y git
 
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Ensure the docs branch
@@ -48,12 +48,12 @@ jobs:
           fi
 
       - name: Checkout the docs branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: docs
 
       - name: Fetch README.md and .pandoc_template.html5 template from the workflow branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout: |
             README.md

--- a/.github/workflows/changelog_to_tag.yml
+++ b/.github/workflows/changelog_to_tag.yml
@@ -22,7 +22,7 @@ jobs:
           sudo apt install -y git
 
       - name: checkout PR
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Get tag and message from the latest CHANGELOG.md commit
         id: tag

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Codespell
         uses: codespell-project/actions-codespell@v2

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -25,7 +25,7 @@ jobs:
           sudo apt install -y git
 
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # CHANGELOG.md is generated automatically from PR titles and descriptions
       # It might have issues but they are not critical

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -18,7 +18,7 @@ jobs:
   commit-checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/qemu-kvm-integration-tests.yml
+++ b/.github/workflows/qemu-kvm-integration-tests.yml
@@ -47,7 +47,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Check if platform is supported
         id: check_platform
@@ -105,7 +105,7 @@ jobs:
           python3 -m pip install --upgrade pip
           sudo apt update
           sudo apt install -y --no-install-recommends git ansible-core genisoimage qemu-system-x86
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.11.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.11.1"
 
       # HACK: Drop this when moving this workflow to 26.04 LTS
       - name: Update podman to 5.x for compatibility with bootc-image-builder's podman 5
@@ -199,7 +199,7 @@ jobs:
               if tox -e "$env" -- --image-file "$(pwd)/$image_file" \
                      --log-level debug $TOX_ARGS \
                      --lsr-report-errors-url DEFAULT \
-                     -e __bootc_validation=true \
+                     -e "__bootc_validation: true" \
                      -- "$test" >out 2>&1; then
                   mv out "${test}-PASS.log"
               else

--- a/.github/workflows/test_converting_readme.yml
+++ b/.github/workflows/test_converting_readme.yml
@@ -26,7 +26,7 @@ jobs:
           sudo apt install -y git
 
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Remove badges from README.md prior to converting to HTML
         run: sed -i '1,8 {/^\[\!.*actions\/workflows/d}' README.md

--- a/.github/workflows/tft.yml
+++ b/.github/workflows/tft.yml
@@ -36,7 +36,7 @@ jobs:
           GITHUB_CONTEXT: ${{ toJson(github) }}
 
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Get head sha of the PR
         id: head_sha
@@ -49,7 +49,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout PR
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ steps.head_sha.outputs.head_sha }}
 

--- a/.github/workflows/tft_citest_bad.yml
+++ b/.github/workflows/tft_citest_bad.yml
@@ -33,8 +33,9 @@ jobs:
             echo "The workflow $PENDING_RUN is still running, wait for it to finish to re-run"
             exit 1
           fi
+          # TF tests can fail or can be cancelled due to TF internal issues
           RUN_ID=$(gh api "repos/$REPO/actions/workflows/tft.yml/runs?event=issue_comment" \
-            | jq -r "[.workflow_runs[] | select( .display_title == \"$PR_TITLE\" ) | select( .conclusion == \"failure\" ) | .id][0]")
+            | jq -r "[.workflow_runs[] | select( .display_title == \"$PR_TITLE\" ) | select( .conclusion == \"failure\" or .conclusion == \"cancelled\" ) | .id][0]")
           if [ "$RUN_ID" = "null" ]; then
             echo "Failed workflow not found, exiting"
             exit 1

--- a/.github/workflows/weekly_ci.yml
+++ b/.github/workflows/weekly_ci.yml
@@ -30,7 +30,7 @@ jobs:
           sudo apt install -y git
 
       - name: Checkout latest code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Create or rebase commit, add dump_packages callback

--- a/.github/workflows/woke.yml
+++ b/.github/workflows/woke.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Run lsr-woke-action
         # Originally, uses: get-woke/woke-action@v0

--- a/contributing.md
+++ b/contributing.md
@@ -19,3 +19,50 @@ are likely to be suitable for new contributors!
 
 **Code** is managed on [Github](https://github.com/linux-system-roles/aide), using
 [Pull Requests](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests).
+
+## Running CI Tests Locally
+
+### Use tox-lsr with qemu
+
+The latest version of tox-lsr supports qemu testing.
+<https://github.com/linux-system-roles/tox-lsr#qemu-testing>
+
+**Steps:**
+
+1. If you are using RHEL or CentOS, enable the EPEL repository for your
+   platform - <https://docs.fedoraproject.org/en-US/epel/>
+
+2. Use yum or dnf to install `standard-test-roles-inventory-qemu`
+   * If for some reason dnf/yum do not work, just download the script from
+     <https://pagure.io/standard-test-roles/raw/master/f/inventory/standard-inventory-qcow2> <!--- wokeignore:rule=master -->
+     * copy to your `$PATH`, and make sure it is executable
+
+3. Install tox
+   * Use yum/dnf to install `python3-tox` - if that does not work, then use
+     `pip install --user tox`, then make sure `~/.local/bin` is in your `$PATH`
+
+4. Install tox-lsr <https://github.com/linux-system-roles/tox-lsr#how-to-get-it>
+
+   ```bash
+   pip install --user git+https://github.com/linux-system-roles/tox-lsr@main
+   ```
+
+5. Download the config file to `~/.config/linux-system-roles.json` from
+   <https://github.com/linux-system-roles/linux-system-roles.github.io/blob/main/download/linux-system-roles.json>
+
+6. Assuming you are in a git clone of a role repo which has a tox.ini file -
+   you can use e.g.
+
+   ```bash
+   tox -e qemu-ansible-core-2.14 -- --image-name centos-9 tests/tests_default.yml
+   ```
+
+There are many command line options and environment variables which can be used
+to control the behavior, and you can customize the testenv in tox.ini. See
+<https://github.com/linux-system-roles/tox-lsr#qemu-testing>
+
+This method supports RHEL also - will download the latest image for a compose,
+and will set up the yum repos to point to internal composes.
+
+See <https://linux-system-roles.github.io/contribute.html> for general
+development guidelines.


### PR DESCRIPTION
Pass in a YAML true value as `__bootc_validation: true` using
the --extra-vars option to ensure that `__bootc_validation` is
treated as a boolean and not a string value.

`-e "__bootc_validation: true"`

You can also use JSON format:

`-e '{"__bootc_validation": true}'`

but YAML is simpler in this case.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Improve CI workflows by upgrading actions and dependencies, refine test parameters, and enrich local testing documentation

CI:
- Upgrade actions/checkout to v5 in all GitHub workflows
- Bump tox-lsr dependency to v3.11.1 in CI pipelines
- Pass __bootc_validation as a YAML boolean in integration tests
- Extend Terraform test failure detection to include cancelled runs

Documentation:
- Add instructions for running CI tests locally with tox-lsr and QEMU