### PR TITLE
test: add role fingerprints to syslog

### DIFF
--- a/tests/tests_default.yml
+++ b/tests/tests_default.yml
@@ -3,24 +3,33 @@
 - name: Ensure that the role runs with default parameters
   hosts: all
   tasks:
+    - name: See if /dev/log exists for the fingerprint check
+      ansible.builtin.stat:
+        path: /dev/log
+      register: __register_dev_log
+
     - name: Set the start time for the journal search
-      set_fact:
+      ansible.builtin.set_fact:
         __journal_start_time: "{{ ansible_facts['date_time']['date'] ~ ' ' ~ ansible_facts['date_time']['time'] }}"
+      when: __register_dev_log.stat.exists
 
     - name: Run the role
       include_tasks: tasks/run_role_with_clear_facts.yml
 
     # look for the exact module invocation, not some other message that might contain the string
     - name: Check system journal contains role fingerprints
-      shell: >-
-        set -eo pipefail;
-        journalctl --since "{{ __journal_start_time }}" --no-pager |
-        grep -v " Invoked with" | grep "sr_fingerprint.*begin system_role:aide" ||
-        { echo ERROR: BEGIN fingerprint not found; exit 1; };
-        journalctl --since "{{ __journal_start_time }}" --no-pager |
-        grep -v " Invoked with" | grep "sr_fingerprint.*success system_role:aide" ||
-        { echo ERROR: SUCCESS fingerprint not found; exit 1; }
+      ansible.builtin.shell:
+        executable: /bin/bash
+        cmd: >-
+          set -eo pipefail;
+          journalctl --since "{{ __journal_start_time }}" --no-pager |
+          grep -v " Invoked with" | grep "sr_fingerprint.*begin system_role:aide" ||
+          { echo ERROR: BEGIN fingerprint not found; exit 1; };
+          journalctl --since "{{ __journal_start_time }}" --no-pager |
+          grep -v " Invoked with" | grep "sr_fingerprint.*success system_role:aide" ||
+          { echo ERROR: SUCCESS fingerprint not found; exit 1; }
       changed_when: false
+      when: __register_dev_log.stat.exists
 
     - name: Check if the file exists
       ansible.builtin.stat:


### PR DESCRIPTION
Test updates based on testing with bootc and on other platforms.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Tests:
- Update default role test to skip journal-based fingerprint checks when /dev/log is absent and to use explicit Ansible module names.