### PR TITLE
refactor: use ansible.posix 2.1.X for EL7 compatibility [citest_skip]

### DIFF
--- a/meta/collection-requirements.yml
+++ b/meta/collection-requirements.yml
@@ -2,3 +2,4 @@
 ---
 collections:
   - name: ansible.posix
+    version: '>=2.1.0,<2.2.0'


### PR DESCRIPTION
The recently released ansible.posix 2.2.0 does not work on EL7.
Pin the version of ansible.posix to 2.1.X.

NOTE: Even though this role might not support EL7, this update
is applied to all system roles for consistency.  Plus, when this
role is part of the system roles collection, all roles must use
the same version of ansible.posix - there is no way for a role
which is part of a collection to use a different version of a
dependency than the version used by the other roles.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the `ansible.posix` collection dependency version constraint to `>=2.1.0,<2.2.0`.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linux-system-roles/aide/pull/85?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->